### PR TITLE
fix: 다른 사람의 다이어리 목록 반환 데이터 추가

### DIFF
--- a/backend/myDiary/movieDiary/views.py
+++ b/backend/myDiary/movieDiary/views.py
@@ -9,6 +9,7 @@ from django.contrib.auth.decorators import login_required
 from .serializers import TestSerializer, JournalCommentSerializer, RecommendedMovieSerializer
 from rest_framework.permissions import IsAuthenticated
 from .models import MovieJournal, Recommended, LikedJournal, JournalComment
+from accounts.models import CustomUser
 from movies.models import Movie
 from django.conf import settings
 from openai import OpenAI
@@ -216,6 +217,7 @@ class MovieJournalViewSet(ModelViewSet):
                     'title': journal.movie.title,
                     'likes': journal.likes.count(),
                     'comments': journal.comments.count(),
+                    'user_first_name': CustomUser.objects.get(pk=serializer.data[i]['user']['id']).first_name
                 }
                 for i, journal in enumerate(page)
             ]
@@ -229,6 +231,7 @@ class MovieJournalViewSet(ModelViewSet):
                 'title': journal.movie.title,
                 'likes': journal.likes.count(),
                 'comments': journal.comments.count(),
+                'user_first_name': CustomUser.objects.get(pk=serializer.data[i]['user']['id']).first_name
             }
             for i, journal in enumerate(queryset)
         ]


### PR DESCRIPTION
- 다른 사람의 다이어리 목록 요청 시, 해당 유저의 이름(first_name) 반환

resolved: #0